### PR TITLE
Removed hardcoded version number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install ./timeseries -vv
-  number: 1
+  number: 2
   script_env:
    - RELEASE=1
 
@@ -33,9 +33,9 @@ requirements:
     - pytorch-lightning <1.8.0,>=1.7.4
     - networkx <3.0,>=2.3
     - tqdm >=4.38.0
-    - autogluon.core ==0.6.2
-    - autogluon.common ==0.6.2
-    - autogluon.tabular ==0.6.2
+    - autogluon.core =={{ version }}
+    - autogluon.common =={{ version }}
+    - autogluon.tabular =={{ version }}
 
 test:
   imports:


### PR DESCRIPTION
The PR removes hardcoded autogluon version number from the dependencies and relaces it with `{{ version}}`. In this way, the recipe can support auto bot merge.